### PR TITLE
Code file to convert exr data to numpy and gif format.

### DIFF
--- a/mfiles/exr/exr2npy.py
+++ b/mfiles/exr/exr2npy.py
@@ -7,6 +7,7 @@ from PIL import Image
 from scipy.io import savemat
 import sys
 import cv2
+import imageio
 
 # Reset to false if using google colab to avoid opencv window imshow call
 viz_output = True
@@ -56,9 +57,11 @@ output_path = sys.argv[1][:-4]
 if(len(tmp) == 3):
     tonemapDurand = cv2.createTonemapReinhard(1.5, 1.0,0.5,0.2)
 else:
-    tonemapDurand = cv2.createTonemapReinhard(0.2, 0.0,0,0)
+    tonemapDurand = cv2.createTonemapReinhard(0.1, 0.0,0,0)
 
 all_transients = []
+all_transients_uint = []
+
 for frame in video_rgb:
     if tone_map:
         frame = tonemapDurand.process(frame)
@@ -66,6 +69,9 @@ for frame in video_rgb:
         cv2.imshow("img", frame/frame.max())
         cv2.waitKey(0)
     all_transients.append(frame/frame.max())
+    all_transients_uint.append((frame/frame.max()*255).astype(np.uint8)[:,:,::-1])
 
+
+imageio.mimsave(output_path+"_all_transients.gif", all_transients_uint[len(all_transients_uint)//2:], fps=20)
 all_transients = np.array(all_transients)
 np.save(output_path+"_all_transients.npy", all_transients)


### PR DESCRIPTION
As many exr images generated using mitsuba renderer have a high dynamic range, I have also added a Reinhard Tonmapping for better visualization of the rendered rgb images.

A code for saving exr data to numpy format would be very useful for python users. Hence creating this PR.

Adding a gif created using this code for the cbox scene. (NOTE: I have skipped initial 500 frames for gif because they were blank, which is expected as these are transient images)

![final_output4_all_transients](https://user-images.githubusercontent.com/42736936/180049559-2074e1ee-ff62-4df3-bfeb-3b9763e98773.gif)
